### PR TITLE
Remove unused pi-hole handler

### DIFF
--- a/tasks/handlers.yml
+++ b/tasks/handlers.yml
@@ -1,11 +1,4 @@
 ---
-- name: Restart pi-hole
-  community.docker.docker_compose_v2:
-    project_src: "{{ config_dir }}/pi-hole/"
-    build: never
-    state: restarted
-  become: false
-
 - name: Restart adguard
   community.docker.docker_compose_v2:
     project_src: "{{ config_dir }}/adguard/"


### PR DESCRIPTION
## Summary
- remove the pi-hole handler from `tasks/handlers.yml`
- ensure no tasks refer to it

## Testing
- `grep -R "Restart pi-hole" -n .`

------
https://chatgpt.com/codex/tasks/task_e_68869818a3508333a64395b0b2f1bb8b