### PR TITLE
Fix ansible-lint violations

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: raspberry
+- name: Configure Raspberry Pi
+  hosts: raspberry
   become: true
 
   pre_tasks:


### PR DESCRIPTION
## Summary
- name main play for clarity
- revert Docker idempotence change for a follow-up PR

## Testing
- `ansible-lint` *(fails: no-changed-when in tasks/docker.yml)*

------
https://chatgpt.com/codex/tasks/task_e_68918b1dd3588333acfe29c11cec66b2