### PR TITLE
Configure network with Google DNS

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,6 +7,16 @@ adguard_enable: true
 open_speed_test_enable: true
 watchtower_enable: true
 
+# Network configuration
+network_conn_name: "eth0"
+network_interface: "eth0"
+network_dns4:
+  - "8.8.8.8"
+  - "8.8.4.4"
+network_dns6:
+  - "2001:4860:4860::8888"
+  - "2001:4860:4860::8844"
+
 # Unattended-upgrades configuration
 # https://github.com/hifis-net/ansible-collection-toolkit/tree/main/roles/unattended_upgrades
 unattended_systemd_timer_override: true

--- a/main.yml
+++ b/main.yml
@@ -19,6 +19,9 @@
       ansible.builtin.import_tasks: tasks/handlers.yml
 
   tasks:
+    - name: Configure network.
+      ansible.builtin.import_tasks: tasks/network.yml
+
     - name: Setup Docker.
       ansible.builtin.import_tasks: tasks/docker.yml
 

--- a/tasks/network.yml
+++ b/tasks/network.yml
@@ -1,0 +1,14 @@
+---
+- name: Configure network connection.
+  community.general.nmcli:
+    conn_name: "{{ network_conn_name }}"
+    ifname: "{{ network_interface }}"
+    type: ethernet
+    autoconnect: true
+    method4: auto
+    method6: auto
+    dns4: "{{ network_dns4 }}"
+    dns4_ignore_auto: true
+    dns6: "{{ network_dns6 }}"
+    dns6_ignore_auto: true
+    state: present


### PR DESCRIPTION
## Summary
- add configurable Google DNS-based network setup using nmcli
- wire network configuration task into main playbook

## Testing
- `ansible-galaxy collection install -r requirements.yml`
- `ansible-playbook -i inventory.ini main.yml --syntax-check`


------
https://chatgpt.com/codex/tasks/task_e_6892b9248b4c833394276a1e8ce79cfc