### PR TITLE
Increase net.core socket buffer limits to 7500000

### DIFF
--- a/tasks/network.yml
+++ b/tasks/network.yml
@@ -17,3 +17,17 @@
     dns6: "{{ network_dns6 }}"
     dns6_ignore_auto: true
     state: present
+
+- name: Increase net.core.rmem_max
+  ansible.posix.sysctl:
+    name: net.core.rmem_max
+    value: 7500000
+    state: present
+    reload: true
+
+- name: Increase net.core.wmem_max
+  ansible.posix.sysctl:
+    name: net.core.wmem_max
+    value: 7500000
+    state: present
+    reload: true

--- a/tasks/network.yml
+++ b/tasks/network.yml
@@ -22,12 +22,8 @@
   ansible.posix.sysctl:
     name: net.core.rmem_max
     value: 7500000
-    state: present
-    reload: true
 
 - name: Increase net.core.wmem_max
   ansible.posix.sysctl:
     name: net.core.wmem_max
     value: 7500000
-    state: present
-    reload: true


### PR DESCRIPTION
## Summary
- raise net.core.rmem_max and net.core.wmem_max to 7500000 via sysctl

## Testing
- `ansible-playbook --syntax-check main.yml`
- `ansible-lint tasks/network.yml`


------
https://chatgpt.com/codex/tasks/task_e_6896b0545c6083339095bfef384bfa43