### PR TITLE
Add templated AdGuard Home configuration

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -7,6 +7,18 @@ adguard_enable: true
 open_speed_test_enable: true
 watchtower_enable: true
 
+# AdGuard configuration
+adguard_user: "victor"
+adguard_password: "PASSWORD_HASH_PLACEHOLDER"
+adguard_upstream_dns:
+  - "h3://dns.google/dns-query"
+adguard_bootstrap_dns:
+  - "192.168.100.1"
+adguard_fallback_dns:
+  - "https://cloudflare-dns.com/dns-query"
+  - "https://anycast.dns.nextdns.io"
+  - "https://dns10.quad9.net/dns-query"
+
 # Network configuration
 # https://docs.ansible.com/ansible/latest/collections/community/general/nmcli_module.html
 network_conn_name: "eth0"

--- a/containers/adguard/confdir/AdGuardHome.yaml.j2
+++ b/containers/adguard/confdir/AdGuardHome.yaml.j2
@@ -1,0 +1,190 @@
+http:
+  pprof:
+    port: 6060
+    enabled: false
+  address: 0.0.0.0:80
+  session_ttl: 720h
+users:
+  - name: {{ adguard_user }}
+    password: {{ adguard_password }}
+auth_attempts: 5
+block_auth_min: 15
+http_proxy: ""
+language: en
+theme: auto
+dns:
+  bind_hosts:
+    - 0.0.0.0
+  port: 53
+  anonymize_client_ip: false
+  ratelimit: 20
+  ratelimit_subnet_len_ipv4: 24
+  ratelimit_subnet_len_ipv6: 56
+  ratelimit_whitelist: []
+  refuse_any: true
+  upstream_dns:
+{% for dns in adguard_upstream_dns %}
+    - {{ dns }}
+{% endfor %}
+  upstream_dns_file: ""
+  bootstrap_dns:
+{% for dns in adguard_bootstrap_dns %}
+    - {{ dns }}
+{% endfor %}
+  fallback_dns:
+{% for dns in adguard_fallback_dns %}
+    - {{ dns }}
+{% endfor %}
+  upstream_mode: load_balance
+  fastest_timeout: 1s
+  allowed_clients: []
+  disallowed_clients: []
+  blocked_hosts:
+    - version.bind
+    - id.server
+    - hostname.bind
+  trusted_proxies:
+    - 127.0.0.0/8
+    - ::1/128
+  cache_size: 4194304
+  cache_ttl_min: 0
+  cache_ttl_max: 0
+  cache_optimistic: false
+  bogus_nxdomain: []
+  aaaa_disabled: false
+  enable_dnssec: true
+  edns_client_subnet:
+    custom_ip: ""
+    enabled: false
+    use_custom: false
+  max_goroutines: 300
+  handle_ddr: true
+  ipset: []
+  ipset_file: ""
+  bootstrap_prefer_ipv6: true
+  upstream_timeout: 10s
+  private_networks: []
+  use_private_ptr_resolvers: false
+  local_ptr_upstreams: []
+  use_dns64: false
+  dns64_prefixes: []
+  serve_http3: false
+  use_http3_upstreams: true
+  serve_plain_dns: true
+  hostsfile_enabled: true
+  pending_requests:
+    enabled: true
+tls:
+  enabled: false
+  server_name: ""
+  force_https: false
+  port_https: 443
+  port_dns_over_tls: 853
+  port_dns_over_quic: 853
+  port_dnscrypt: 0
+  dnscrypt_config_file: ""
+  allow_unencrypted_doh: false
+  certificate_chain: ""
+  private_key: ""
+  certificate_path: ""
+  private_key_path: ""
+  strict_sni_check: false
+querylog:
+  dir_path: ""
+  ignored: []
+  interval: 168h
+  size_memory: 1000
+  enabled: true
+  file_enabled: true
+statistics:
+  dir_path: ""
+  ignored: []
+  interval: 168h
+  enabled: true
+filters:
+  - enabled: false
+    url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_1.txt
+    name: AdGuard DNS filter
+    id: 1
+  - enabled: false
+    url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_2.txt
+    name: AdAway Default Blocklist
+    id: 2
+  - enabled: true
+    url: https://adguardteam.github.io/HostlistsRegistry/assets/filter_34.txt
+    name: HaGeZi's Normal Blocklist
+    id: 1753227173
+whitelist_filters: []
+user_rules: []
+dhcp:
+  enabled: false
+  interface_name: ""
+  local_domain_name: lan
+  dhcpv4:
+    gateway_ip: ""
+    subnet_mask: ""
+    range_start: ""
+    range_end: ""
+    lease_duration: 86400
+    icmp_timeout_msec: 1000
+    options: []
+  dhcpv6:
+    range_start: ""
+    lease_duration: 86400
+    ra_slaac_only: false
+    ra_allow_slaac: false
+filtering:
+  blocking_ipv4: ""
+  blocking_ipv6: ""
+  blocked_services:
+    schedule:
+      time_zone: Local
+    ids: []
+  protection_disabled_until: null
+  safe_search:
+    enabled: false
+    bing: true
+    duckduckgo: true
+    ecosia: true
+    google: true
+    pixabay: true
+    yandex: true
+    youtube: true
+  blocking_mode: default
+  parental_block_host: family-block.dns.adguard.com
+  safebrowsing_block_host: standard-block.dns.adguard.com
+  rewrites: []
+  safe_fs_patterns:
+    - /opt/adguardhome/work/userfilters/*
+  safebrowsing_cache_size: 1048576
+  safesearch_cache_size: 1048576
+  parental_cache_size: 1048576
+  cache_time: 30
+  filters_update_interval: 24
+  blocked_response_ttl: 10
+  filtering_enabled: true
+  parental_enabled: false
+  safebrowsing_enabled: false
+  protection_enabled: true
+clients:
+  runtime_sources:
+    whois: true
+    arp: true
+    rdns: false
+    dhcp: true
+    hosts: true
+  persistent: []
+log:
+  enabled: true
+  file: ""
+  max_backups: 0
+  max_size: 100
+  max_age: 3
+  compress: false
+  local_time: false
+  verbose: false
+os:
+  group: ""
+  user: ""
+  rlimit_nofile: 0
+schema_version: 29

--- a/tasks/adguard.yml
+++ b/tasks/adguard.yml
@@ -12,10 +12,27 @@
     dest: "{{ config_dir }}/adguard/docker-compose.yml"
     mode: "0640"
   become: false
-  notify: Restart adguard
+  register: adguard_compose
 
-- name: Ensure adguard is running.
+- name: Create adguard confdir folder on Pi.
+  ansible.builtin.file:
+    path: "{{ config_dir }}/adguard/confdir"
+    state: directory
+    mode: "0755"
+  become: false
+
+- name: Copy AdGuard configuration to Pi.
+  ansible.builtin.template:
+    src: containers/adguard/confdir/AdGuardHome.yaml.j2
+    dest: "{{ config_dir }}/adguard/confdir/AdGuardHome.yaml"
+    mode: "0640"
+  become: false
+  register: adguard_config
+
+- name: Start or restart adguard.
   community.docker.docker_compose_v2:
     project_src: "{{ config_dir }}/adguard/"
     build: never
+    state: restarted
+  when: adguard_compose.changed or adguard_config.changed
   become: false

--- a/tasks/docker.yml
+++ b/tasks/docker.yml
@@ -18,6 +18,7 @@
   environment:
     CHANNEL: stable
   when: docker_command_result.rc == 1
+  changed_when: docker_command_result.rc == 1
 
 - name: Ensure Docker is started.
   ansible.builtin.service:

--- a/tasks/handlers.yml
+++ b/tasks/handlers.yml
@@ -1,11 +1,4 @@
 ---
-- name: Restart adguard
-  community.docker.docker_compose_v2:
-    project_src: "{{ config_dir }}/adguard/"
-    build: never
-    state: restarted
-  become: false
-
 - name: Restart openspeedtest
   community.docker.docker_compose_v2:
     project_src: "{{ config_dir }}/openspeedtest/"


### PR DESCRIPTION
## Summary
- add AdGuard Home configuration template and copy step
- allow configuring user credentials and DNS servers via `config.yml`
- use placeholder password and create confdir immediately before copying rendered config
- only start/restart AdGuard after both compose file and configuration are in place
- add `changed_when` for Docker install script to satisfy lint

## Testing
- `ansible-playbook --syntax-check main.yml`
- `ansible-lint`


------
https://chatgpt.com/codex/tasks/task_e_6898e8e87de08333a4209ea05a253feb