### PR TITLE
Install Argon ONE setup script via Ansible

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -22,6 +22,9 @@
     - name: Configure network.
       ansible.builtin.import_tasks: tasks/network.yml
 
+    - name: Install Argon ONE script.
+      ansible.builtin.import_tasks: tasks/argonone.yml
+
     - name: Setup Docker.
       ansible.builtin.import_tasks: tasks/docker.yml
 

--- a/tasks/argonone.yml
+++ b/tasks/argonone.yml
@@ -1,0 +1,19 @@
+---
+- name: Check if Argon ONE script is already present.
+  ansible.builtin.command: which argon-config
+  failed_when: false
+  changed_when: false
+  check_mode: false
+  register: argon_config_command_result
+
+- name: Download Argon ONE install script.
+  ansible.builtin.get_url:
+    url: https://raw.githubusercontent.com/okunze/Argon40-ArgonOne-Script/master/source/argon1.sh
+    dest: /tmp/argon1.sh
+    mode: "0775"
+  when: argon_config_command_result.rc == 1
+
+- name: Run Argon ONE install script.
+  ansible.builtin.command: /tmp/argon1.sh
+  when: argon_config_command_result.rc == 1
+  changed_when: argon_config_command_result.rc == 1


### PR DESCRIPTION
## Summary
- add task to install Argon ONE script when `argon-config` is missing
- include Argon ONE setup in main playbook

## Testing
- `uvx --from ansible-core ansible-playbook --syntax-check -i inventory.ini main.yml`


------
https://chatgpt.com/codex/tasks/task_e_6898f59da0c883338cf01d4a35aa3901